### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/website.i2pd.i2pd.json
+++ b/website.i2pd.i2pd.json
@@ -12,9 +12,16 @@
         "--device=dri"
     ],
     "cleanup": [
+        "/bin/upnpc", 
+        "/bin/external-ip",
         "/cache",
-        "/share/doc", "/share/man", "/bin/upnpc", "/bin/external-ip",
-        "*.la", "*.a"
+        "/include",
+        "/lib/cmake",
+        "/lib/pkgconfig",
+        "/share/doc", 
+        "/share/man", 
+        "*.la", 
+        "*.a"
     ],
     "modules": [
         {


### PR DESCRIPTION
Cleanup development files to reduce the Flatpak size.

Installed size reduced from 153.0 MB to 6.8 MB.

```
du -ha -d2
176M	./include/boost
56K    	./include/miniupnpc
176M	./include
36K    	./lib/cmake
4,0K	./lib/pkgconfig
```
